### PR TITLE
fix(cleanstring): remove untraditional whitespace with no ignored words

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 -->
 
 <!--
-  emdaerHash:f2d515e552db21d4208b11c9914af364
+  emdaerHash:ca7d5c67504df7e2749942c4e68f225b
 -->
 
 <h1 id="path-cleanstring">path-cleanstring</h1>
@@ -28,10 +28,10 @@ Drupal module <a href="https://www.drupal.org/project/pathauto">pathauto</a>‘s
 <p>Type: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></p>
 <h2 id="cleanstring">cleanstring</h2>
 <p>Constructs a method for cleaning strings.</p>
-<p>Note: passed in config is merged
-  with the default config, but not recursively. Therefore, if you override one
-  of the arrays or objects in the config you must provide all the members that
-  you would like that array or object to contain.</p>
+<p>Note: passed in config is merged with the default config, but not
+  recursively. Therefore, if you override one of the arrays or objects in the
+  config you must provide all the members that you would like that array or
+  object to contain.</p>
 <p><strong>Parameters</strong></p>
 <ul>
 <li><code>config</code> <strong>CleanstringConfig</strong> The config object to use for cleaning. Anything passed in here will be
@@ -39,19 +39,26 @@ Drupal module <a href="https://www.drupal.org/project/pathauto">pathauto</a>‘s
   config.punctuation you will need to provide values for every punctionation
   character you wish to handle. (optional, default <code>defaultConfig</code>)<ul>
 <li><code>config.case</code> <strong><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></strong> True if the generated string should be lowercased. (optional, default <code>true</code>)</li>
-<li><code>config.ignoreWords</code> <strong><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>&gt;</strong> The list of words to strip from the passed in string. (optional, default <code>[&#39;a&#39;,&#39;an&#39;,&#39;as&#39;,&#39;at&#39;,&#39;before&#39;,&#39;but&#39;,&#39;by&#39;,&#39;for&#39;,&#39;from&#39;,&#39;is&#39;,&#39;in&#39;,&#39;into&#39;,&#39;like&#39;,&#39;of&#39;,&#39;off&#39;,&#39;on&#39;,&#39;onto&#39;,&#39;per&#39;,&#39;since&#39;,&#39;than&#39;,&#39;the&#39;,&#39;this&#39;,&#39;that&#39;,&#39;to&#39;,&#39;up&#39;,&#39;via&#39;,&#39;with&#39;]</code>)</li>
+<li><code>config.ignoreWords</code> <strong><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>&gt;</strong> The list of words to strip from the passed in string. (optional, default <code>[
+&#39;a&#39;,&#39;an&#39;,&#39;as&#39;,&#39;at&#39;,&#39;before&#39;,
+&#39;but&#39;,&#39;by&#39;,&#39;for&#39;,&#39;from&#39;,&#39;is&#39;,
+&#39;in&#39;,&#39;into&#39;,&#39;like&#39;,&#39;of&#39;,&#39;off&#39;,
+&#39;on&#39;,&#39;onto&#39;,&#39;per&#39;,&#39;since&#39;,&#39;than&#39;,
+&#39;the&#39;,&#39;this&#39;,&#39;that&#39;,&#39;to&#39;,&#39;up&#39;,
+&#39;via&#39;,&#39;with&#39;
+]</code>)</li>
 <li><code>config.maxComponentLength</code> <strong>int</strong> The maximum length of the resulting string. The string will be split on
   boundaries so it may be shorter than this value, but will never be longer. (optional, default <code>100</code>)</li>
 <li><code>config.punctuation</code> <strong><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></strong> The punctuation directives, each member of this object will have a value of
   CLEANSTRING_REMOVE, CLEANSTRING_REPLACE, or CLEANSTRING_DONOTHING which
-  will determine how the characters are handled during cleaning (optional, default <code>{
+  will determine how the characters are handled during cleaning. (optional, default <code>{
 &#39;&quot;&#39;:CLEANSTRING_REMOVE,
 &quot;&#39;&quot;:CLEANSTRING_REMOVE,
 &#39;`&#39;:CLEANSTRING_REMOVE,
 &#39;,&#39;:CLEANSTRING_REMOVE,
 &#39;.&#39;:CLEANSTRING_REMOVE,
 &#39;-&#39;:CLEANSTRING_REMOVE,
-_:CLEANSTRING_REMOVE,
+&#39;_&#39;:CLEANSTRING_REMOVE,
 &#39;:&#39;:CLEANSTRING_REMOVE,
 &#39;;&#39;:CLEANSTRING_REMOVE,
 &#39;|&#39;:CLEANSTRING_REMOVE,

--- a/src/index.js
+++ b/src/index.js
@@ -224,7 +224,7 @@ function cleanstring(
       );
     }
 
-    // Then remove any ignored words and trim whitespace.
+    // Then remove any ignored words.
     if (mergedConfig.ignoreWords.length) {
       retString = retString
         .replace(
@@ -233,6 +233,9 @@ function cleanstring(
         )
         .trim();
     }
+
+    // Then trim any whitespace.
+    retString = retString.trim();
 
     // Then reduce the string to ASCII only characters.
     if (mergedConfig.reduceAscii) {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -59,4 +59,13 @@ describe('cleanstring', () => {
       'a-quick-brown-8bit-fox-jumps-onto-the-lazy-dog-vinyl-cursus-nibh-eros-pharetra-vim-congue-a-risus'
     );
   });
+
+  test('can trim untraditional whitespace with no ignored words', () => {
+    expect.assertions(1);
+    expect(
+      cleanstring({
+        ignoreWords: [],
+      })(`hello world${decodeURIComponent('%c2%a0')}`)
+    ).toBe('hello-world');
+  });
 });


### PR DESCRIPTION
trim() was called if there were any ignored words, but not if
there weren't. This allowed things like nonbreaking spaces
to slip through and cause problems.