### PR TITLE
feat(cleanstring): handle string transliteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 -->
 
 <!--
-  emdaerHash:ca7d5c67504df7e2749942c4e68f225b
+  emdaerHash:7268887a47f1e3ce33070c351ce04a13
 -->
 
 <h1 id="path-cleanstring">path-cleanstring</h1>
@@ -28,10 +28,10 @@ Drupal module <a href="https://www.drupal.org/project/pathauto">pathauto</a>‘s
 <p>Type: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></p>
 <h2 id="cleanstring">cleanstring</h2>
 <p>Constructs a method for cleaning strings.</p>
-<p>Note: passed in config is merged with the default config, but not
-  recursively. Therefore, if you override one of the arrays or objects in the
-  config you must provide all the members that you would like that array or
-  object to contain.</p>
+<p>Note: passed in config is merged
+  with the default config, but not recursively. Therefore, if you override one
+  of the arrays or objects in the config you must provide all the members that
+  you would like that array or object to contain.</p>
 <p><strong>Parameters</strong></p>
 <ul>
 <li><code>config</code> <strong>CleanstringConfig</strong> The config object to use for cleaning. Anything passed in here will be
@@ -39,26 +39,19 @@ Drupal module <a href="https://www.drupal.org/project/pathauto">pathauto</a>‘s
   config.punctuation you will need to provide values for every punctionation
   character you wish to handle. (optional, default <code>defaultConfig</code>)<ul>
 <li><code>config.case</code> <strong><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></strong> True if the generated string should be lowercased. (optional, default <code>true</code>)</li>
-<li><code>config.ignoreWords</code> <strong><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>&gt;</strong> The list of words to strip from the passed in string. (optional, default <code>[
-&#39;a&#39;,&#39;an&#39;,&#39;as&#39;,&#39;at&#39;,&#39;before&#39;,
-&#39;but&#39;,&#39;by&#39;,&#39;for&#39;,&#39;from&#39;,&#39;is&#39;,
-&#39;in&#39;,&#39;into&#39;,&#39;like&#39;,&#39;of&#39;,&#39;off&#39;,
-&#39;on&#39;,&#39;onto&#39;,&#39;per&#39;,&#39;since&#39;,&#39;than&#39;,
-&#39;the&#39;,&#39;this&#39;,&#39;that&#39;,&#39;to&#39;,&#39;up&#39;,
-&#39;via&#39;,&#39;with&#39;
-]</code>)</li>
+<li><code>config.ignoreWords</code> <strong><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>&gt;</strong> The list of words to strip from the passed in string. (optional, default <code>[&#39;a&#39;,&#39;an&#39;,&#39;as&#39;,&#39;at&#39;,&#39;before&#39;,&#39;but&#39;,&#39;by&#39;,&#39;for&#39;,&#39;from&#39;,&#39;is&#39;,&#39;in&#39;,&#39;into&#39;,&#39;like&#39;,&#39;of&#39;,&#39;off&#39;,&#39;on&#39;,&#39;onto&#39;,&#39;per&#39;,&#39;since&#39;,&#39;than&#39;,&#39;the&#39;,&#39;this&#39;,&#39;that&#39;,&#39;to&#39;,&#39;up&#39;,&#39;via&#39;,&#39;with&#39;]</code>)</li>
 <li><code>config.maxComponentLength</code> <strong>int</strong> The maximum length of the resulting string. The string will be split on
   boundaries so it may be shorter than this value, but will never be longer. (optional, default <code>100</code>)</li>
 <li><code>config.punctuation</code> <strong><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></strong> The punctuation directives, each member of this object will have a value of
   CLEANSTRING_REMOVE, CLEANSTRING_REPLACE, or CLEANSTRING_DONOTHING which
-  will determine how the characters are handled during cleaning. (optional, default <code>{
+  will determine how the characters are handled during cleaning (optional, default <code>{
 &#39;&quot;&#39;:CLEANSTRING_REMOVE,
 &quot;&#39;&quot;:CLEANSTRING_REMOVE,
 &#39;`&#39;:CLEANSTRING_REMOVE,
 &#39;,&#39;:CLEANSTRING_REMOVE,
 &#39;.&#39;:CLEANSTRING_REMOVE,
 &#39;-&#39;:CLEANSTRING_REMOVE,
-&#39;_&#39;:CLEANSTRING_REMOVE,
+_:CLEANSTRING_REMOVE,
 &#39;:&#39;:CLEANSTRING_REMOVE,
 &#39;;&#39;:CLEANSTRING_REMOVE,
 &#39;|&#39;:CLEANSTRING_REMOVE,
@@ -70,6 +63,8 @@ Drupal module <a href="https://www.drupal.org/project/pathauto">pathauto</a>‘s
 &#39;</code>)</li>
 <li><code>config.reduceAscii</code> <strong><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></strong> True if the generated string should have all non-ascii characters removed. (optional, default <code>false</code>)</li>
 <li><code>config.separator</code> <strong><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></strong> The character to use to separate words on boundaries. (optional, default <code>&#39;-&#39;</code>)</li>
+<li><code>config.transliterate</code> <strong><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></strong> True if the generated string should have non-ascii characters
+  transliterated. (optional, default <code>false</code>)</li>
 </ul>
 </li>
 </ul>

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "semantic-release-conventional-commits": "^2.0.1"
   },
   "dependencies": {
-    "striptags": "^3.1.1"
+    "striptags": "^3.1.1",
+    "transliteration": "^2.1.3"
   },
   "engines": {
     "node": ">=8.10"

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 const striptags = require('striptags');
+const { transliterate } = require('transliteration');
 
 const REG_EXP_CHAR = /[\\^$.*+?()[\]{}|]/g;
 const REG_EXP_ASCII = /[^a-zA-Z0-9/]+/g;
@@ -97,6 +98,7 @@ const defaultConfig: CleanstringConfig = {
   },
   reduceAscii: false,
   separator: '-',
+  transliterate: false,
 };
 
 /**
@@ -160,6 +162,9 @@ const defaultConfig: CleanstringConfig = {
  *   True if the generated string should have all non-ascii characters removed.
  * @param {string} [config.separator='-']
  *   The character to use to separate words on boundaries.
+ * @param {boolean} [config.transliterate=false]
+ *   True if the generated string should have non-ascii characters
+ *   transliterated.
  *
  * @return {CleanstringCallback}
  *   A function which can be used to clean strings. Accepts a string as its only
@@ -234,6 +239,10 @@ function cleanstring(
 
     // Then trim any whitespace.
     retString = retString.trim();
+
+    if (mergedConfig.transliterate) {
+      retString = transliterate(retString);
+    }
 
     // Then reduce the string to ASCII only characters.
     if (mergedConfig.reduceAscii) {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -68,4 +68,13 @@ describe('cleanstring', () => {
       })(`hello world${decodeURIComponent('%c2%a0')}`)
     ).toBe('hello-world');
   });
+
+  test('can handle accent characters', () => {
+    expect.assertions(1);
+    expect(
+      cleanstring({
+        transliterate: true,
+      })('Bonne Santé')
+    ).toBe('bonne-sante');
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10077,6 +10077,13 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+transliteration@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/transliteration/-/transliteration-2.1.3.tgz#1406f3d3038723c4720493f3c63ff0d85a8b9db7"
+  integrity sha512-i7OLuBgUnjzn2HDsuo/BEAaC/9lHwAJYokPBto5MXDsH1yyT0yPVOAmTO18ZH/9JP7sJYd51QqcsMRka+0+mlQ==
+  dependencies:
+    yargs "^13.1.0"
+
 "traverse@>=0.3.0 <0.4":
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"


### PR DESCRIPTION
This is performed using the [transliteration](https://www.npmjs.com/package/transliteration) module.
The operation is disabled by default but can be enabled by setting the `transliteration` config member to `true`.