### PR TITLE
fix(cleanstring): remove trailing ellipsis

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -254,6 +254,7 @@ function cleanstring(
 
       // Then filter down the string to fit within the max length.
       const components = retString
+        .replace(/…$/, '')
         .replace(/\s{2,}/g, ' ')
         .split(' ')
         .filter(i => i);

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -77,4 +77,9 @@ describe('cleanstring', () => {
       })('Bonne Santé')
     ).toBe('bonne-sante');
   });
+
+  test('can remove trailing ellipsis', () => {
+    expect.assertions(1);
+    expect(cleanstring()('Hello world…')).toBe('hello-world');
+  });
 });


### PR DESCRIPTION
This is lifted from Drupal's truncate_utf8 method which removes trailing
ellipses before shortening the string.