### PR TITLE
fix(cleanstring): transliterate ellipsis

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -215,6 +215,10 @@ function cleanstring(
       // First, strip tags.
       let retString = striptags(string);
 
+      if (mergedConfig.transliterate) {
+        retString = transliterate(retString).replace('…', '...');
+      }
+
       // Then remove desired punctuation.
       if (punctuation[CLEANSTRING_REMOVE].length) {
         retString = retString.replace(
@@ -242,10 +246,6 @@ function cleanstring(
 
       // Then trim any whitespace.
       retString = retString.trim();
-
-      if (mergedConfig.transliterate) {
-        retString = transliterate(retString);
-      }
 
       // Then reduce the string to ASCII only characters.
       if (mergedConfig.reduceAscii) {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -69,12 +69,23 @@ describe('cleanstring', () => {
     ).toBe('hello-world');
   });
 
-  test('can handle accent characters', () => {
-    expect.assertions(1);
-    expect(
-      cleanstring({
-        transliterate: true,
-      })('Bonne Santé')
-    ).toBe('bonne-sante');
+  describe('transliteration', () => {
+    test('can handle accent characters', () => {
+      expect.assertions(1);
+      expect(
+        cleanstring({
+          transliterate: true,
+        })('Bonne Santé')
+      ).toBe('bonne-sante');
+    });
+
+    test('can convert ellipses', () => {
+      expect.assertions(1);
+      expect(
+        cleanstring({
+          transliterate: true,
+        })('Hello world…')
+      ).toBe('hello-world');
+    });
   });
 });


### PR DESCRIPTION
Drupal's transliterate method converts ellipses into `...`. The
result is that the characters are removed when `.` is included in
the punctuation to remove.